### PR TITLE
Core: Create wallet methods

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -11,19 +11,28 @@ import (
 type APIServer struct {
 	Blockchain *core.Blockchain
 	server     *http.Server
+	Wallet     *core.Wallet
 }
 
 func NewAPIServer(bc *core.Blockchain) *APIServer {
+	wallet := core.NewWallet()
 	return &APIServer{
 		Blockchain: bc,
+		Wallet:     wallet,
 		server: &http.Server{
 			Addr: ":8080",
 		},
 	}
 }
 
+
 func (s *APIServer) Start() error {
 	http.HandleFunc("/blocks", s.handleGetBlocks)
+	http.HandleFunc("/wallet/address", s.handleWalletAddress)
+	http.HandleFunc("/wallet/sign", s.handleWalletSign)
+	http.HandleFunc("/wallet/verify", s.handleWalletVerify)
+	http.HandleFunc("/wallet/keys", s.handleWalletKeys)
+
 	fmt.Println("API server listening on http://localhost:8080")
 	return s.server.ListenAndServe()
 }
@@ -36,4 +45,59 @@ func (s *APIServer) Shutdown(ctx context.Context) error {
 func (s *APIServer) handleGetBlocks(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	_ = json.NewEncoder(w).Encode(s.Blockchain.Blocks)
+}
+
+func (s *APIServer) handleWalletAddress(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"address": s.Wallet.GetAddress(),
+	})
+}
+
+func (s *APIServer) handleWalletSign(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Message string `json:"message"`
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+
+	sig, err := s.Wallet.Sign([]byte(req.Message))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"signature": fmt.Sprintf("%x", sig),
+	})
+}
+
+func (s *APIServer) handleWalletVerify(w http.ResponseWriter, r *http.Request) {
+	var req struct {
+		Message   string `json:"message"`
+		Signature string `json:"signature"`
+	}
+	json.NewDecoder(r.Body).Decode(&req)
+
+	sigBytes := make([]byte, 64)
+	_, err := fmt.Sscanf(req.Signature, "%x", &sigBytes)
+	if err != nil {
+		http.Error(w, "Invalid signature format", http.StatusBadRequest)
+		return
+	}
+
+	valid := s.Wallet.Verify([]byte(req.Message), sigBytes)
+
+	json.NewEncoder(w).Encode(map[string]bool{
+		"valid": valid,
+	})
+}
+
+func (s *APIServer) handleWalletKeys(w http.ResponseWriter, r *http.Request) {
+	priv, _ := s.Wallet.ExportPrivateKey()
+	pub, _ := s.Wallet.ExportPublicKey()
+
+	json.NewEncoder(w).Encode(map[string]string{
+		"private_key": string(priv),
+		"public_key":  string(pub),
+	})
 }

--- a/core/wallet.go
+++ b/core/wallet.go
@@ -33,7 +33,9 @@ func (w *Wallet) GetAddress() string {
 
 func (w *Wallet) Sign(data []byte) ([]byte, error) {
 	r, s, err := ecdsa.Sign(rand.Reader, w.PrivateKey, data)
-	if err != nil {
+	if len(data) == 0 {
+		return nil, fmt.Errorf("data to sign cannot be empty")
+	} else if err != nil {
 		return nil, err
 	}
 	return append(r.Bytes(), s.Bytes()...), nil


### PR DESCRIPTION
This pull request introduces wallet functionality to the API server, enabling cryptographic operations such as signing, verification, and key export. The most important changes include adding a `Wallet` to the `APIServer`, implementing new API endpoints for wallet-related operations, and enhancing the `Sign` method in the `Wallet` class to handle empty data.

### API Server Enhancements:

* Added a `Wallet` field to the `APIServer` and initialized it in the `NewAPIServer` constructor.
* Introduced new API endpoints:
  - [`/wallet/address`](diffhunk://#diff-a5457320f6b67f92cbcb51459dd5ebd160912638c6b22d0964e52921b58a05d9R49-R103): Retrieves the wallet's address.
  - [`/wallet/sign`](diffhunk://#diff-a5457320f6b67f92cbcb51459dd5ebd160912638c6b22d0964e52921b58a05d9R49-R103): Signs a message using the wallet's private key.
  - [`/wallet/verify`](diffhunk://#diff-a5457320f6b67f92cbcb51459dd5ebd160912638c6b22d0964e52921b58a05d9R49-R103): Verifies a signature against a message.
  - [`/wallet/keys`](diffhunk://#diff-a5457320f6b67f92cbcb51459dd5ebd160912638c6b22d0964e52921b58a05d9R49-R103): Exports the wallet's private and public keys.

### Wallet Functionality Enhancements:

* Updated the `Sign` method in `Wallet` to return an error if the data to be signed is empty, improving robustness.