### PR TITLE
Fix: Return pointer to LatestBlock()

### DIFF
--- a/blockchain/core/blockchain.go
+++ b/blockchain/core/blockchain.go
@@ -31,6 +31,6 @@ func (bc *Blockchain) AddBlock(txns []Transaction) {
 	bc.Blocks = append(bc.Blocks, newBlock)
 }
 
-func (bc *Blockchain) LatestBlock() Block {
-	return bc.Blocks[len(bc.Blocks)-1]
+func (bc *Blockchain) LatestBlock() *Block {
+	return &bc.Blocks[len(bc.Blocks)-1]
 }


### PR DESCRIPTION
This pull request modifies the `LatestBlock` method in the `Blockchain` struct to return a pointer to the latest block instead of a value. This change improves efficiency by avoiding unnecessary copying of the `Block` struct.

* `blockchain/core/blockchain.go`:
  - Changed the return type of `func (bc *Blockchain) LatestBlock()` from `Block` to `*Block`, ensuring the method returns a pointer to the latest block.