### PR TITLE
Core: Add mutex to protect the blockchain

### DIFF
--- a/blockchain/core/blockchain.go
+++ b/blockchain/core/blockchain.go
@@ -2,10 +2,12 @@ package core
 
 import (
 	"time"
+	"sync"
 )
 
 type Blockchain struct {
 	Blocks []Block
+	mu     sync.Mutex
 }
 
 func NewBlockchain() *Blockchain {
@@ -20,6 +22,9 @@ func NewBlockchain() *Blockchain {
 }
 
 func (bc *Blockchain) AddBlock(txns []Transaction) {
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
+
 	prev := bc.Blocks[len(bc.Blocks)-1]
 	newBlock := Block{
 		Index:        prev.Index + 1,


### PR DESCRIPTION
This pull request introduces thread-safety to the `Blockchain` implementation by adding a mutex to ensure safe concurrent access when modifying the blockchain. The key changes include adding a `sync.Mutex` to the `Blockchain` struct and using it to lock and unlock critical sections in the `AddBlock` method.

### Enhancements for thread-safety:

* [`blockchain/core/blockchain.go`](diffhunk://#diff-a4d02c2e41baba2f957bdb4b1e949efb34415eb07da087b055555a2a78740371R5-R10): Added a `sync.Mutex` field (`mu`) to the `Blockchain` struct to enable thread-safe operations.
* [`blockchain/core/blockchain.go`](diffhunk://#diff-a4d02c2e41baba2f957bdb4b1e949efb34415eb07da087b055555a2a78740371R25-R27): Updated the `AddBlock` method to lock the mutex before modifying the `Blocks` slice and to unlock it after the operation is completed.