### PR TITLE
Fix: Validate non-empty data before signing

### DIFF
--- a/blockchain/core/wallet.go
+++ b/blockchain/core/wallet.go
@@ -2,12 +2,12 @@ package core
 
 import (
 	"crypto/ecdsa"
+	"crypto/elliptic"
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"crypto/elliptic"
 )
 
 type Wallet struct {
@@ -32,11 +32,12 @@ func (w *Wallet) GetAddress() string {
 }
 
 func (w *Wallet) Sign(data []byte) ([]byte, error) {
-	r, s, err := ecdsa.Sign(rand.Reader, w.PrivateKey, data)
 	if len(data) == 0 {
 		return nil, fmt.Errorf("data to sign cannot be empty")
-	} else if err != nil {
-		return nil, err
+	}
+	r, s, err := ecdsa.Sign(rand.Reader, w.PrivateKey, data)
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign data: %v", err)
 	}
 	return append(r.Bytes(), s.Bytes()...), nil
 }


### PR DESCRIPTION
This pull request includes improvements to the `blockchain/core/wallet.go` file, focusing on code quality and error handling in the `Sign` method, as well as a minor import reorganization.

### Code quality and error handling:

* Improved the `Sign` method in the `Wallet` struct by restructuring the error handling logic. It now checks for empty input data before attempting to sign and provides a more descriptive error message when signing fails. (`[blockchain/core/wallet.goL35-R40](diffhunk://#diff-ce31201d2c09d852da76b68bdaa9a1cc3ce3557975bfebec53be8e4b224f4325L35-R40)`)

### Import reorganization:

* Reorganized imports in `wallet.go` by moving `crypto/elliptic` to maintain alphabetical order and grouping. (`[blockchain/core/wallet.goR5-L10](diffhunk://#diff-ce31201d2c09d852da76b68bdaa9a1cc3ce3557975bfebec53be8e4b224f4325R5-L10)`)