### PR TITLE
Fix: Hash the public key and return something more wallet-friendly

### DIFF
--- a/blockchain/core/wallet.go
+++ b/blockchain/core/wallet.go
@@ -34,8 +34,11 @@ func NewWallet() *Wallet {
 }
 
 func (w *Wallet) GetAddress() string {
-	return fmt.Sprintf("%x", w.PublicKey.X)
+    pubKeyBytes := append(w.PublicKey.X.Bytes(), w.PublicKey.Y.Bytes()...)
+    hashed := sha256.Sum256(pubKeyBytes)
+    return fmt.Sprintf("%x", hashed[:20]) // 20 byte address
 }
+
 
 func (w *Wallet) Sign(data []byte) ([]byte, error) {
 	if len(data) == 0 {


### PR DESCRIPTION
This pull request updates the address generation logic in the `Wallet` class to enhance security by hashing the public key before truncating it to create the address.

### Changes to address generation:

* [`blockchain/core/wallet.go`](diffhunk://#diff-ce31201d2c09d852da76b68bdaa9a1cc3ce3557975bfebec53be8e4b224f4325L37-R42): Updated the `GetAddress` method to hash the concatenated X and Y coordinates of the public key using SHA-256 and return the first 20 bytes of the hash as the wallet address. This ensures a more secure and consistent address format.