### PR TITLE
Core: Let users import keys from PEM to restore a wallet

### DIFF
--- a/blockchain/core/wallet.go
+++ b/blockchain/core/wallet.go
@@ -80,3 +80,19 @@ func (w *Wallet) ExportPublicKey() ([]byte, error) {
 	}
 	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubBytes}), nil
 }
+
+func ImportPrivateKey(pemBytes []byte) (*Wallet, error) {
+   block, _ := pem.Decode(pemBytes)
+   if block == nil || block.Type != "PRIVATE KEY" {
+       return nil, fmt.Errorf("invalid PEM format")
+   }
+   key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+   if err != nil {
+       return nil, err
+   }
+   priv, ok := key.(*ecdsa.PrivateKey)
+   if !ok {
+       return nil, fmt.Errorf("not an ECDSA private key")
+   }
+   return &Wallet{PrivateKey: priv, PublicKey: &priv.PublicKey}, nil
+}


### PR DESCRIPTION
This pull request introduces a new method to the `Wallet` struct for importing private keys from PEM-encoded data. This addition enhances the functionality of the wallet by allowing private keys to be imported and used programmatically.

### New functionality for key management:
* Added `ImportPrivateKey` method to the `Wallet` struct in `blockchain/core/wallet.go`. This method decodes a PEM-encoded private key, validates its format, and parses it into an ECDSA private key. If successful, it initializes a new `Wallet` instance with the imported private key and its corresponding public key.