### PR TITLE
Core: Write tests for wallet functionalities

### DIFF
--- a/blockchain/core/wallet_test.go
+++ b/blockchain/core/wallet_test.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"testing"
+)
+
+func TestNewWallet(t *testing.T) {
+	wallet := NewWallet()
+	if wallet.PrivateKey == nil {
+		t.Error("Expected PrivateKey to be non-nil")
+	}
+	if wallet.PublicKey == nil {
+		t.Error("Expected PublicKey to be non-nil")
+	}
+	if wallet.PublicKey != &wallet.PrivateKey.PublicKey {
+		t.Error("PublicKey does not match PrivateKey.PublicKey")
+	}
+}
+
+func TestGetAddress(t *testing.T) {
+	wallet := NewWallet()
+	address := wallet.GetAddress()
+	if len(address) != 40 {
+		t.Errorf("Expected address length of 40, got %d", len(address))
+	}
+}
+
+func TestSignAndVerify(t *testing.T) {
+	wallet := NewWallet()
+	message := []byte("Hello, blockchain!")
+	sig, err := wallet.Sign(message)
+	if err != nil {
+		t.Errorf("Sign failed: %v", err)
+	}
+	if len(sig) != 64 {
+		t.Errorf("Expected signature length of 64, got %d", len(sig))
+	}
+
+	if !wallet.Verify(message, sig) {
+		t.Error("Expected signature to be valid")
+	}
+
+	if wallet.Verify([]byte("Tampered message"), sig) {
+		t.Error("Expected tampered signature to be invalid")
+	}
+}
+
+func TestSignEmptyData(t *testing.T) {
+	wallet := NewWallet()
+	sig, err := wallet.Sign([]byte{})
+	if err == nil {
+		t.Error("Expected error when signing empty data")
+	}
+	if sig != nil {
+		t.Error("Expected nil signature on error")
+	}
+}
+
+func TestKeyExportImport(t *testing.T) {
+	originalWallet := NewWallet()
+
+	privPEM, err := originalWallet.ExportPrivateKey()
+	if err != nil || privPEM == nil {
+		t.Fatalf("Failed to export private key: %v", err)
+	}
+
+	pubPEM, err := originalWallet.ExportPublicKey()
+	if err != nil || pubPEM == nil {
+		t.Fatalf("Failed to export public key: %v", err)
+	}
+
+	importedWallet, err := ImportPrivateKey(privPEM)
+	if err != nil || importedWallet == nil {
+		t.Fatalf("Failed to import wallet: %v", err)
+	}
+
+	message := []byte("Reconstructed wallet test")
+	sig, err := importedWallet.Sign(message)
+	if err != nil {
+		t.Errorf("Sign failed: %v", err)
+	}
+
+	if !importedWallet.Verify(message, sig) {
+		t.Error("Signature verification failed on imported wallet")
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,10 @@ module github.com/sammyklan3/finality
 
 go 1.24.5
 
-require github.com/sammyklan3/finality/blockchain v0.0.0-20250804105757-61e9a089a559 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sammyklan3/finality/blockchain v0.0.0-20250804165127-8f116be1ca4b // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,11 @@
-github.com/sammyklan3/finality/blockchain v0.0.0-20250804105757-61e9a089a559 h1:Yn3nEpSNRY9DWByNv6uxrtBJiAJJ/EmTIm9cdNERUsk=
-github.com/sammyklan3/finality/blockchain v0.0.0-20250804105757-61e9a089a559/go.mod h1:czUpuaofFdMNDkrR5evs0O0tKYFKq4AF/Xqh78IgrMo=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/sammyklan3/finality/blockchain v0.0.0-20250804165127-8f116be1ca4b h1:ais6R7Fj9drDjy5oQOwtBs+IFUP8Ur3Ku1MQ1UMhPRI=
+github.com/sammyklan3/finality/blockchain v0.0.0-20250804165127-8f116be1ca4b/go.mod h1:czUpuaofFdMNDkrR5evs0O0tKYFKq4AF/Xqh78IgrMo=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This pull request adds comprehensive unit tests for the wallet functionality in the blockchain core module and updates the project dependencies to support testing and related features.

**Testing improvements:**

* Added `wallet_test.go` in `blockchain/core` with tests for wallet creation, address generation, signing/verifying messages, error handling for signing empty data, and key export/import.

**Dependency updates:**

* Updated `go.mod` to include new indirect dependencies: `github.com/stretchr/testify` for testing assertions, and other libraries (`go-spew`, `go-difflib`, `yaml.v3`) to support testing and utility functions. Also updated the reference for `github.com/sammyklan3/finality/blockchain`.