### PR TITLE
Core: Add TCP communication and Handshake validation between Nodes

### DIFF
--- a/cmd/node/main.go
+++ b/cmd/node/main.go
@@ -1,90 +1,92 @@
 package main
 
 import (
-    "crypto/ecdsa"
-    "crypto/elliptic"
-    "crypto/rand"
-    "crypto/sha256"
-    "encoding/hex"
-    "flag"
-    "fmt"
-    "log"
-    "os"
-    "os/signal"
-    "strings"
-    "syscall"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
 
-    "finality/internal/p2p"
+	"finality/internal/p2p"
 )
 
 func main() {
-    // Command-line flags
-    udpPort := flag.Int("udp-port", 30303, "UDP port for peer discovery")
-    tcpPort := flag.Int("tcp-port", 30304, "TCP port for node connections")
-    bootstrapPeers := flag.String("bootnodes", "", "Comma-separated list of bootstrap peers (ip:port)")
-    flag.Parse()
+	// Command-line flags
+	udpPort := flag.Int("udp-port", 30303, "UDP port for peer discovery")
+	tcpPort := flag.Int("tcp-port", 30304, "TCP port for node connections")
+	bootstrapPeers := flag.String("bootnodes", "", "Comma-separated list of bootstrap peers (ip:port)")
+	flag.Parse()
 
-    // Parse bootstrap peers into a slice BEFORE usage
-    var bootnodes []string
-    if *bootstrapPeers != "" {
-        bootnodes = splitAndTrim(*bootstrapPeers)
-    }
+	// Parse bootstrap peers into a slice BEFORE usage
+	var bootnodes []string
+	if *bootstrapPeers == "" {
+		bootnodes = []string{"127.0.0.1:30303"} // or any known bootstrap node IP:port
+	} else {
+		bootnodes = splitAndTrim(*bootstrapPeers)
+	}
 
-    // Generate ECDSA private key for the node
-    privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-    if err != nil {
-        log.Fatalf("Failed to generate node key: %v", err)
-    }
+	// Generate ECDSA private key for the node
+	privKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		log.Fatalf("Failed to generate node key: %v", err)
+	}
 
-    chainID := "finality-mainnet" // or configurable
+	chainID := "finality-mainnet" // or configurable
 
-    listenTCPAddr := fmt.Sprintf("0.0.0.0:%d", *tcpPort)
+	listenTCPAddr := fmt.Sprintf("0.0.0.0:%d", *tcpPort)
 
-    node := p2p.NewNode(privKey, chainID, listenTCPAddr)
+	node := p2p.NewNode(privKey, chainID, listenTCPAddr)
 
-    if err := node.Start(); err != nil {
-        log.Fatalf("Failed to start TCP server: %v", err)
-    }
+	if err := node.Start(); err != nil {
+		log.Fatalf("Failed to start TCP server: %v", err)
+	}
 
-    // Connect to bootstrap peers discovered via UDP
-    for _, addr := range bootnodes {
-        go func(a string) {
-            if err := node.Connect(a); err != nil {
-                log.Printf("Failed to connect to peer %s: %v", a, err)
-            }
-        }(addr)
-    }
+	// Connect to bootstrap peers discovered via UDP
+	for _, addr := range bootnodes {
+		go func(a string) {
+			if err := node.Connect(a); err != nil {
+				log.Printf("Failed to connect to peer %s: %v", a, err)
+			}
+		}(addr)
+	}
 
-    // Derive node ID as sha256(pubkeyBytes)
-    pubKeyBytes := append(privKey.PublicKey.X.Bytes(), privKey.PublicKey.Y.Bytes()...)
-    nodeID := sha256.Sum256(pubKeyBytes)
-    nodeIDHex := hex.EncodeToString(nodeID[:])
+	// Derive node ID as sha256(pubkeyBytes)
+	pubKeyBytes := append(privKey.PublicKey.X.Bytes(), privKey.PublicKey.Y.Bytes()...)
+	nodeID := sha256.Sum256(pubKeyBytes)
+	nodeIDHex := hex.EncodeToString(nodeID[:])
 
-    fmt.Printf("Node ID: %s\n", nodeIDHex)
+	fmt.Printf("Node ID: %s\n", nodeIDHex)
 
-    // Start UDP discovery with generated NodeID
-    listenAddr := fmt.Sprintf("0.0.0.0:%d", *udpPort)
-    discovery, err := p2p.NewDiscovery(nodeIDHex, listenAddr, bootnodes)
-    if err != nil {
-        log.Fatalf("Failed to start discovery: %v", err)
-    }
-    discovery.Start()
-    defer discovery.Stop()
+	// Start UDP discovery with generated NodeID
+	listenAddr := fmt.Sprintf("0.0.0.0:%d", *udpPort)
+	discovery, err := p2p.NewDiscovery(nodeIDHex, listenAddr, bootnodes)
+	if err != nil {
+		log.Fatalf("Failed to start discovery: %v", err)
+	}
+	discovery.Start()
+	defer discovery.Stop()
 
-    fmt.Printf("Finality node started.\nUDP discovery listening on %s\nTCP connections will listen on 0.0.0.0:%d\n", listenAddr, *tcpPort)
+	fmt.Printf("Finality node started.\nUDP discovery listening on %s\nTCP connections will listen on 0.0.0.0:%d\n", listenAddr, *tcpPort)
 
-    // Graceful shutdown on Ctrl+C
-    sigs := make(chan os.Signal, 1)
-    signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
-    <-sigs
-    fmt.Println("\nShutting down node...")
+	// Graceful shutdown on Ctrl+C
+	sigs := make(chan os.Signal, 1)
+	signal.Notify(sigs, os.Interrupt, syscall.SIGTERM)
+	<-sigs
+	fmt.Println("\nShutting down node...")
 }
 
 // Helper to split comma-separated bootstrap peers and trim spaces
 func splitAndTrim(s string) []string {
-    var res []string
-    for _, p := range strings.Split(s, ",") {
-        res = append(res, strings.TrimSpace(p))
-    }
-    return res
+	var res []string
+	for _, p := range strings.Split(s, ",") {
+		res = append(res, strings.TrimSpace(p))
+	}
+	return res
 }

--- a/internal/p2p/discovery.go
+++ b/internal/p2p/discovery.go
@@ -9,11 +9,6 @@ import (
     "time"
 )
 
-type Peer struct {
-    NodeID  string
-    Address string
-}
-
 type Packet struct {
     Type       string   `json:"type"`
     NodeID     string   `json:"node_id"`

--- a/internal/p2p/handshake.go
+++ b/internal/p2p/handshake.go
@@ -1,1 +1,69 @@
 package p2p
+
+import (
+    "encoding/json"
+    "fmt"
+    "io"
+    "net"
+)
+
+const ProtocolVersion = "finality/1.0"
+
+type HandshakeMessage struct {
+    NodeID          string `json:"node_id"`
+    ProtocolVersion string `json:"protocol_version"`
+    ChainID         string `json:"chain_id"`
+}
+
+func WriteHandshake(conn net.Conn, msg HandshakeMessage) error {
+    data, err := json.Marshal(msg)
+    if err != nil {
+        return err
+    }
+    // Write length-prefixed message
+    length := uint32(len(data))
+    lenBuf := []byte{
+        byte(length >> 24),
+        byte(length >> 16),
+        byte(length >> 8),
+        byte(length),
+    }
+    if _, err := conn.Write(lenBuf); err != nil {
+        return err
+    }
+    if _, err := conn.Write(data); err != nil {
+        return err
+    }
+    return nil
+}
+
+func ReadHandshake(conn net.Conn) (HandshakeMessage, error) {
+    var msg HandshakeMessage
+    lenBuf := make([]byte, 4)
+    if _, err := io.ReadFull(conn, lenBuf); err != nil {
+        return msg, err
+    }
+    length := (uint32(lenBuf[0]) << 24) | (uint32(lenBuf[1]) << 16) | (uint32(lenBuf[2]) << 8) | uint32(lenBuf[3])
+    data := make([]byte, length)
+    if _, err := io.ReadFull(conn, data); err != nil {
+        return msg, err
+    }
+    if err := json.Unmarshal(data, &msg); err != nil {
+        return msg, err
+    }
+    return msg, nil
+}
+
+// Validate handshake fields (protocol version match, chain ID, etc.)
+func ValidateHandshake(localChainID string, msg HandshakeMessage) error {
+    if msg.ProtocolVersion != ProtocolVersion {
+        return fmt.Errorf("protocol version mismatch: got %s, want %s", msg.ProtocolVersion, ProtocolVersion)
+    }
+    if msg.ChainID != localChainID {
+        return fmt.Errorf("chain ID mismatch: got %s, want %s", msg.ChainID, localChainID)
+    }
+    if msg.NodeID == "" {
+        return fmt.Errorf("empty node ID in handshake")
+    }
+    return nil
+}

--- a/internal/p2p/node.go
+++ b/internal/p2p/node.go
@@ -1,1 +1,145 @@
 package p2p
+
+import (
+    "crypto/ecdsa"
+    "fmt"
+    "log"
+    "net"
+    "sync"
+    "time"
+)
+
+type Node struct {
+    privKey   *ecdsa.PrivateKey
+    NodeID    string
+    ChainID   string
+
+    listenAddr string
+    listener   net.Listener
+
+    peers      map[string]*Peer
+    peersMutex sync.Mutex
+}
+
+func NewNode(privKey *ecdsa.PrivateKey, chainID, listenAddr string) *Node {
+    pubKeyBytes := append(privKey.PublicKey.X.Bytes(), privKey.PublicKey.Y.Bytes()...)
+    nodeID := fmt.Sprintf("%x", pubKeyBytes) // Simple hex encoding, improve if needed
+
+    return &Node{
+        privKey:    privKey,
+        NodeID:     nodeID,
+        ChainID:    chainID,
+        listenAddr: listenAddr,
+        peers:      make(map[string]*Peer),
+    }
+}
+
+// Start TCP server to accept inbound connections
+func (n *Node) Start() error {
+    ln, err := net.Listen("tcp", n.listenAddr)
+    if err != nil {
+        return err
+    }
+    n.listener = ln
+    log.Printf("TCP server listening on %s", n.listenAddr)
+
+    go n.acceptLoop()
+    return nil
+}
+
+func (n *Node) acceptLoop() {
+    for {
+        conn, err := n.listener.Accept()
+        if err != nil {
+            log.Printf("Listener accept error: %v", err)
+            continue
+        }
+        go n.handleConnection(conn, false)
+    }
+}
+
+// Connect to a peer (outbound)
+func (n *Node) Connect(addr string) error {
+    conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+    if err != nil {
+        return err
+    }
+    go n.handleConnection(conn, true)
+    return nil
+}
+
+// Handle a new TCP connection (inbound or outbound)
+func (n *Node) handleConnection(conn net.Conn, outbound bool) {
+    defer func() {
+        conn.Close()
+    }()
+
+    // Run handshake
+    peerNodeID, err := n.runHandshake(conn, outbound)
+    if err != nil {
+        log.Printf("Handshake failed with %s: %v", conn.RemoteAddr(), err)
+        return
+    }
+    log.Printf("Handshake successful with peer %s", peerNodeID)
+
+    peer := NewPeer(conn)
+    peer.NodeID = peerNodeID
+
+    n.peersMutex.Lock()
+    n.peers[peerNodeID] = peer
+    n.peersMutex.Unlock()
+
+    peer.ReadLoop()
+
+    // Remove peer on disconnect
+    n.peersMutex.Lock()
+    delete(n.peers, peerNodeID)
+    n.peersMutex.Unlock()
+}
+
+// runHandshake performs the TCP handshake
+func (n *Node) runHandshake(conn net.Conn, outbound bool) (string, error) {
+    localMsg := HandshakeMessage{
+        NodeID:          n.NodeID,
+        ProtocolVersion: ProtocolVersion,
+        ChainID:         n.ChainID,
+    }
+
+    if outbound {
+        // Outbound: send first, then read
+        if err := WriteHandshake(conn, localMsg); err != nil {
+            return "", err
+        }
+        remoteMsg, err := ReadHandshake(conn)
+        if err != nil {
+            return "", err
+        }
+        if err := ValidateHandshake(n.ChainID, remoteMsg); err != nil {
+            return "", err
+        }
+        return remoteMsg.NodeID, nil
+    } else {
+        // Inbound: read first, then send
+        remoteMsg, err := ReadHandshake(conn)
+        if err != nil {
+            return "", err
+        }
+        if err := ValidateHandshake(n.ChainID, remoteMsg); err != nil {
+            return "", err
+        }
+        if err := WriteHandshake(conn, localMsg); err != nil {
+            return "", err
+        }
+        return remoteMsg.NodeID, nil
+    }
+}
+
+// Disconnect peer by nodeID
+func (n *Node) Disconnect(peerID string) {
+    n.peersMutex.Lock()
+    defer n.peersMutex.Unlock()
+    if peer, ok := n.peers[peerID]; ok {
+        peer.Close()
+        delete(n.peers, peerID)
+    }
+}

--- a/internal/p2p/peer.go
+++ b/internal/p2p/peer.go
@@ -1,1 +1,67 @@
 package p2p
+
+import (
+    "fmt"
+    "log"
+    "net"
+    "sync"
+)
+
+type Peer struct {
+    Conn   net.Conn
+    NodeID string
+    Address string
+
+    sendLock sync.Mutex
+    // Add more fields as needed: message queues, status, etc.
+}
+
+func NewPeer(conn net.Conn) *Peer {
+    return &Peer{
+        Conn: conn,
+    }
+}
+
+func (p *Peer) Close() {
+    p.Conn.Close()
+}
+
+func (p *Peer) Send(data []byte) error {
+    p.sendLock.Lock()
+    defer p.sendLock.Unlock()
+    // Send length-prefixed messages
+    length := uint32(len(data))
+    lenBuf := []byte{
+        byte(length >> 24),
+        byte(length >> 16),
+        byte(length >> 8),
+        byte(length),
+    }
+    if _, err := p.Conn.Write(lenBuf); err != nil {
+        return err
+    }
+    if _, err := p.Conn.Write(data); err != nil {
+        return err
+    }
+    return nil
+}
+
+// Start reading from the peer connection (can spawn goroutine here)
+func (p *Peer) ReadLoop() {
+    for {
+        lengthBuf := make([]byte, 4)
+        if _, err := p.Conn.Read(lengthBuf); err != nil {
+            log.Printf("Peer %s disconnected: %v", p.NodeID, err)
+            return
+        }
+        length := (uint32(lengthBuf[0]) << 24) | (uint32(lengthBuf[1]) << 16) | (uint32(lengthBuf[2]) << 8) | uint32(lengthBuf[3])
+        data := make([]byte, length)
+        if _, err := p.Conn.Read(data); err != nil {
+            log.Printf("Peer %s disconnected during read: %v", p.NodeID, err)
+            return
+        }
+
+        // TODO: handle incoming message data here
+        fmt.Printf("Received message from %s: %x\n", p.NodeID, data)
+    }
+}


### PR DESCRIPTION
This pull request introduces a basic TCP peer-to-peer (P2P) networking stack, including peer management, handshake protocol, and message framing. The main changes are the addition of TCP server/client logic, a handshake protocol for peer authentication, and new abstractions for nodes and peers.

**TCP P2P Networking and Peer Management:**

* Added a `Node` abstraction in `node.go` that manages TCP connections, peer state, and handshake logic. Nodes can now start a TCP server, connect to peers, and handle inbound/outbound connections with handshake verification.
* Introduced a `Peer` abstraction in `peer.go` with connection management, message sending/receiving (length-prefixed), and a read loop for incoming messages.
* Refactored the main entrypoint (`main.go`) to start the TCP server, connect to bootstrap peers, and integrate the new `Node` logic. [[1]](diffhunk://#diff-41988d47676978b9c3637b55fba6588aed77dab7cff1aadfb41b119964785392R27-L45) [[2]](diffhunk://#diff-41988d47676978b9c3637b55fba6588aed77dab7cff1aadfb41b119964785392L57-L58)

**Handshake Protocol:**

* Implemented a handshake protocol in `handshake.go` to exchange node ID, protocol version, and chain ID between peers. Includes handshake validation and error handling for mismatches.

**Code Cleanup and Refactoring:**

* Removed the old `Peer` struct from `discovery.go` as peer management is now handled by the new abstractions.